### PR TITLE
Various tune ups for Debian packaging

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,40 +1,41 @@
 btrbk (0.19.3-1) unstable; urgency=medium
 
   * New upstream release.
+  * Initial debian packaging (Closes: #791797)
   * Bugfix: fix sorting of dates in schedule().
-  * Bugfix: correct parsing of btrfs subvolume list (closes: #28).
+  * Bugfix: correct parsing of btrfs subvolume list (close: #28).
   * Support for btrfs-progs v4.1-rc1.
 
  -- Axel Burri <axel@tty0.ch>  Sun, 21 Jun 2015 15:39:05 +0200
 
-btrbk (0.19.2-1) unstable; urgency=low
+btrbk (0.19.2-1) UNRELEASED; urgency=low
 
   * New upstream release.
-  * Bugfix: fix crash when using btrfs-progs < 3.17.3 (closes: #24).
+  * Bugfix: fix crash when using btrfs-progs < 3.17.3 (close: #24).
 
  -- Axel Burri <axel@tty0.ch>  Sun, 07 Jun 2015 12:37:27 +0200
 
-btrbk (0.19.1-1) unstable; urgency=medium
+btrbk (0.19.1-1) UNRELEASED; urgency=medium
 
   * New upstream release.
   * Use "cgen" for snapshot comparison.
-  * Bugfix: fix crash in summary display (closes: #22).
+  * Bugfix: fix crash in summary display (close: #22).
 
  -- Axel Burri <axel@tty0.ch>  Mon, 01 Jun 2015 12:53:14 +0200
 
-btrbk (0.19.0-1) unstable; urgency=medium
+btrbk (0.19.0-1) UNRELEASED; urgency=medium
 
   * New upstream release.
   * Added "snapshot_create onchange", which skips snapshot creation if
     the latest snapshot is up-to-date (i.e. has same generation as the
     source subvolume).
   * Improved handling of command line subvolume filter for "run",
-    "dryrun" and "tree" actions (closes: #21).
+    "dryrun" and "tree" actions (close: #21).
   * Bugfix: fixed crash in action "diff".
 
  -- Axel Burri <axel@tty0.ch>  Wed, 27 May 2015 17:38:45 +0200
 
-btrbk (0.18.0-1) unstable; urgency=medium
+btrbk (0.18.0-1) UNRELEASED; urgency=medium
 
   * New upstream release.
   * MIGRATION
@@ -44,41 +45,41 @@ btrbk (0.18.0-1) unstable; urgency=medium
       - "snapshot_create_always no"  -> "snapshot_create ondemand"
   * Set PATH variable instead of using absolute "/sbin/btrfs" for
     compatibility with all linux distros out there, which all install
-    'btrfs' in different locations (closes: #20).
+    'btrfs' in different locations (close: #20).
   * Added configuration option "snapshot_create", replacing option
     "snapshot_create_always". This allows setups with multiple btrbk
-    instances on several hosts (closes: #18).
+    instances on several hosts (close: #18).
   * Added command line option -r (resume only).
   * Catch and display errors from "btrfs subvolume show".
   * Include systemd service and timer unit for daily backups.
 
  -- Axel Burri <axel@tty0.ch>  Thu, 21 May 2015 15:58:44 +0200
 
-btrbk (0.17.1-1) unstable; urgency=medium
+btrbk (0.17.1-1) UNRELEASED; urgency=medium
 
   * New upstream release.
   * Bugfix: send/receive: delete possibly left-behind garbled
     subvolume on failure. Fail with unrecoverable error if stray
-    target subvolume is in the way (closes: #17).
+    target subvolume is in the way (close: #17).
   * Bugfix: assume unreachable target as clean on snapshot creation if
-    snapshot_create_always is set (closes: #19).
+    snapshot_create_always is set (close: #19).
 
  -- Axel Burri <axel@tty0.ch>  Fri, 15 May 2015 18:00:14 +0100
 
-btrbk (0.17.0-1) unstable; urgency=medium
+btrbk (0.17.0-1) UNRELEASED; urgency=medium
 
   * New upstream release.
   * New versioning scheme using more common three-level versions.
   * Code refactoring: cleanup of data structures and handling of btrfs
     subvolume tree, as well as security related code parts.
-  * Correct handling of symlinks to btrfs subvolumes (closes: #12).
-  * Added configuration option "snapshot_name" (closes: #5).
+  * Correct handling of symlinks to btrfs subvolumes (close: #12).
+  * Added configuration option "snapshot_name" (close: #5).
   * Log messages now go to stderr, only the summary is printed on
     stdout.
-  * Bugfix: allow "0" as subvolume name (closes: #10).
-  * Bugfix: allow "/" as volume name (closes: #15).
+  * Bugfix: allow "0" as subvolume name (close: #10).
+  * Bugfix: allow "/" as volume name (close: #15).
   * Bugfix: check source AND targets for determining snapshot postfix
-    (closes: #11).
+    (close: #11).
   * Bugfix: fixed "diff" action (colses: #14).
   * Allow '+' character for subvolume names.
   * Filesystems on remote hosts are now printed as
@@ -86,20 +87,20 @@ btrbk (0.17.0-1) unstable; urgency=medium
 
  -- Axel Burri <axel@tty0.ch>  Thu, 30 Apr 2015 14:52:44 +0100
 
-btrbk (0.16-1) unstable; urgency=high
+btrbk (0.16-1) UNRELEASED; urgency=high
 
   * New upstream release.
   * Bugfix: correctly check retention policy for missing backups
 
  -- Axel Burri <axel@tty0.ch>  Wed, 02 Apr 2015 17:27:22 +0100
 
-btrbk (0.15-1) unstable; urgency=low
+btrbk (0.15-1) UNRELEASED; urgency=low
 
   * New upstream release.
   * Added configuration option "btrfs_progs_compat", to be enabled if
-    using btrfs-progs < 3.17 (closes: #6).
+    using btrfs-progs < 3.17 (close: #6).
   * Added configuration option "resume_missing", for automatic resume
-    of missing backups (closes: #8).
+    of missing backups (close: #8).
   * Removed configuration option "receive_log" in favor of printing
     errors from "btrfs receive".
   * Bugfix: show correct exit code on external command failure.
@@ -107,33 +108,33 @@ btrbk (0.15-1) unstable; urgency=low
 
  -- Axel Burri <axel@tty0.ch>  Wed, 01 Apr 2015 17:01:06 +0100
 
-btrbk (0.14-1) unstable; urgency=low
+btrbk (0.14-1) UNRELEASED; urgency=low
 
   * New upstream release.
   * Bugfix: correctly handle empty target subvolumes (blocker for all
-    new users; closes: #4).
+    new users; close: #4).
 
  -- Axel Burri <axel@tty0.ch>  Fri, 20 Mar 2015 18:08:47 +0100
 
-btrbk (0.13-1) unstable; urgency=low
+btrbk (0.13-1) UNRELEASED; urgency=low
 
   * New upstream release.
   * Bugfix: allow '@' character for subvolume names (blocker for
     ubuntu users, since ubuntu prefixes all subvolumes with '@' in its
-    subvolume layout; closes: #3).
+    subvolume layout; close: #3).
 
  -- Axel Burri <axel@tty0.ch>  Thu, 19 Mar 2015 17:20:46 +0100
 
-btrbk (0.12-1) unstable; urgency=low
+btrbk (0.12-1) UNRELEASED; urgency=low
 
   * New upstream release.
   * Cleaner and more generic parsing of btrfs subvolume list.
-  * Bugfix: subvolumes are also allowed for "snapshot_dir" (closes:
+  * Bugfix: subvolumes are also allowed for "snapshot_dir" (close:
     #1, #2).
 
  -- Axel Burri <axel@tty0.ch>  Fri, 13 Mar 2015 19:39:42 +0100
 
-btrbk (0.11-1) unstable; urgency=low
+btrbk (0.11-1) UNRELEASED; urgency=low
 
   * New upstream release.
   * Added option -p (preserve backups).
@@ -143,7 +144,7 @@ btrbk (0.11-1) unstable; urgency=low
 
  -- Axel Burri <axel@tty0.ch>  Mon, 2 Mar 2015 11:35:22 +0100
 
-btrbk (0.10-1) unstable; urgency=low
+btrbk (0.10-1) UNRELEASED; urgency=low
 
   * Initial release.
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: btrbk
 Section: utils
 Priority: optional
 Maintainer: Axel Burri <axel@tty0.ch>
-Standards-Version: 3.9.4
+Standards-Version: 3.9.6
 Build-Depends: debhelper (>= 7)
 Homepage: http://www.digint.ch/btrbk/
 

--- a/debian/control
+++ b/debian/control
@@ -3,14 +3,14 @@ Section: utils
 Priority: optional
 Maintainer: Axel Burri <axel@tty0.ch>
 Standards-Version: 3.9.6
-Build-Depends: debhelper (>= 7)
+Build-Depends: debhelper (>= 9)
 Homepage: http://www.digint.ch/btrbk/
 
 Package: btrbk
 Architecture: all
-Depends: perl, libdate-calc-perl, btrfs-tools (>= 3.14)
+Depends: perl, libdate-calc-perl, btrfs-tools (>= 3.14), ${misc:Depends}
 Suggests: openssh-client
-Description: Backup tool for btrfs volumes
+Description: backup tool for btrfs volumes
  Backup tool for btrfs volumes, using a configuration file, allows
  creation of backups from multiple sources to multiple destinations at
  once, with ssh and configurable retention support

--- a/debian/copyright
+++ b/debian/copyright
@@ -4,10 +4,10 @@ Source: http://www.digint.ch/download/btrbk/releases/
 
 Files: *
 Copyright: 2014-2015 Axel Burri <axel@tty0.ch>
-License: GPL-2+<special license>
+License: GPL-3+
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
- the Free Software Foundation; either version 2 of the License, or
+ the Free Software Foundation; either version 3 of the License, or
  (at your option) any later version.
  .
  This package is distributed in the hope that it will be useful,
@@ -19,4 +19,4 @@ License: GPL-2+<special license>
  along with this program. If not, see <http://www.gnu.org/licenses/>
  .
  On Debian systems, the complete text of the GNU General
- Public License version 2 can be found in "/usr/share/common-licenses/GPL-2".
+ Public License version 3 can be found in "/usr/share/common-licenses/GPL".

--- a/debian/rules
+++ b/debian/rules
@@ -3,29 +3,7 @@
 # output every command that modifies files on the build system.
 #DH_VERBOSE = 1
 
-# see EXAMPLES in dpkg-buildflags(1) and read /usr/share/dpkg/*
-DPKG_EXPORT_BUILDFLAGS = 1
-include /usr/share/dpkg/default.mk
-
-# see FEATURE AREAS in dpkg-buildflags(1)
-#export DEB_BUILD_MAINT_OPTIONS = hardening=+all
-
-# see ENVIRONMENT in dpkg-buildflags(1)
-# package maintainers to append CFLAGS
-#export DEB_CFLAGS_MAINT_APPEND  = -Wall -pedantic
-# package maintainers to append LDFLAGS
-#export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
-
 # main packaging script based on dh7 syntax
 %:
-	dh $@ 
-
-# debmake generated override targets
-# This is example for Cmake (See http://bugs.debian.org/641051 )
-#override_dh_auto_configure:
-#	dh_auto_configure -- \
-#	-DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)
-
-
-
+	dh $@
 


### PR DESCRIPTION
```
$> git lg origin/debian..
* 290c249 - (HEAD, gh-yarikoptic/debian, debian) debian/copyright: prev releases to UNRELEASED, close: instead of closes:, added ITP Closes statement (82 seconds ago) [Yaroslav Halchenko]
* 6355552 - debian/control: higher version for dh, added misc:Depends, and short description is a continuation of "btrbk is" so lower case (3 minutes ago) [Yaroslav Halchenko]
* 8f8c1b6 - adjusted license to be GPL-3+ (16 minutes ago) [Yaroslav Halchenko]
* fd59882 - removed not-applicable/commented out snippets in rules (16 minutes ago) [Yaroslav Halchenko]
* a7ec0d7 - boosted policy to current version (16 minutes ago) [Yaroslav Halchenko]
```

also I have created a gbp.conf which you might like to add (as debian/gbp.conf) if you happen to use git-buildpackage (really neat):

```
$> cat .git/gbp.conf 
# Configuration file for gbp
[DEFAULT]
upstream-branch = master
debian-branch = debian
debian-tag = debian/%(version)s
upstream-tag = v%(version)s
```