### PR TITLE
Update cron examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Retention policy:
 
 /etc/cron.daily/btrbk:
 
-    #!/bin/bash
+    #!/bin/sh
     /usr/sbin/btrbk -q -c /etc/btrbk/btrbk-mylaptop.conf run
 
 
@@ -226,7 +226,7 @@ regular basis:
 
 /etc/cron.daily/btrbk:
 
-    #!/bin/bash
+    #!/bin/sh
     /usr/sbin/btrbk -q run
 
 Note that you can run btrbk more than once a day, e.g. by creating the

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Retention policy:
 /etc/cron.daily/btrbk:
 
     #!/bin/sh
-    /usr/sbin/btrbk -q -c /etc/btrbk/btrbk-mylaptop.conf run
+    exec /usr/sbin/btrbk -q -c /etc/btrbk/btrbk-mylaptop.conf run
 
 
 - This will create snapshots on a daily basis:
@@ -227,7 +227,7 @@ regular basis:
 /etc/cron.daily/btrbk:
 
     #!/bin/sh
-    /usr/sbin/btrbk -q run
+    exec /usr/sbin/btrbk -q run
 
 Note that you can run btrbk more than once a day, e.g. by creating the
 above script in `/etc/cron.hourly/btrbk`, or by calling `sudo btrbk

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Retention policy:
 /etc/cron.daily/btrbk:
 
     #!/bin/bash
-    /usr/sbin/btrbk -c /etc/btrbk/btrbk-mylaptop.conf run
+    /usr/sbin/btrbk -q -c /etc/btrbk/btrbk-mylaptop.conf run
 
 
 - This will create snapshots on a daily basis:
@@ -227,7 +227,7 @@ regular basis:
 /etc/cron.daily/btrbk:
 
     #!/bin/bash
-    /usr/sbin/btrbk run
+    /usr/sbin/btrbk -q run
 
 Note that you can run btrbk more than once a day, e.g. by creating the
 above script in `/etc/cron.hourly/btrbk`, or by calling `sudo btrbk


### PR DESCRIPTION
The example crontab entries from the README don't specify `-q` which will result in a mail being sent every run. I've added this option and also made two style-related changes (`/bin/sh` instead of `/bin/bash` and using `exec` which is slightly more efficient because the shell process does not have to be kept in memory during the run). Feel free to drop one or both of these commits if you don't feel comfortable with them.

Thanks a lot for your work on btrbk!