### PR TITLE
Fix new option "timestamp_format long"

### DIFF
--- a/btrbk
+++ b/btrbk
@@ -3064,7 +3064,7 @@ MAIN:
           # find unique snapshot name
           my $timestamp = ((config_key($config_subvol, "timestamp_format") eq "short") ?
                            sprintf("%04d%02d%02d", @today) :
-                           sprintf("%04d%02d%02dT%02d%02d", @today_and_now));
+                           sprintf("%04d%02d%02dT%02d%02d", @today_and_now[0..4]));
           my @unconfirmed_target_name;
           my @lookup = keys %{vinfo_subvol_list($sroot)};
           @lookup = grep s/^\Q$snapdir\E// , @lookup;


### PR DESCRIPTION
When I use the option "timestamp_format long", I have the following error:

ERROR: process died unexpectedly (btrbk v0.21.0)
Please contact the author: Axel Burri <axel@tty0.ch>

Stack Trace:
----------------------------------------
Redundant argument in sprintf at /usr/sbin/btrbk line 3065.
 at /usr/sbin/btrbk line 184.
        main::__ANON__("Redundant argument in sprintf at /usr/sbin/btrbk line 3065.\x{a}") called at /usr/sbin/btrbk line 3065

This pull request fixes the problem and seems to work on Gentoo.