### PR TITLE
btrbk-mail: Use `btrbk` instead of unbound variable `$btrbk`

### DIFF
--- a/contrib/cron/btrbk-mail
+++ b/contrib/cron/btrbk-mail
@@ -113,7 +113,7 @@ case $exitcode in
 	;;
     10) status="ERROR: At least one backup task aborted!"
 	;;
-    *)  status="ERROR: $btrbk failed with error code $exitcode"
+    *)  status="ERROR: btrbk failed with error code $exitcode"
 	;;
 esac
 


### PR DESCRIPTION
When the script goe sinto the `*)` branch of the `case`, it tries to interpret the unbound variable `$btrbk`. This results in a crash without useful error output.