### PR TITLE
btrbk: Prefix PATH instead of resetting it.

### DIFF
--- a/btrbk
+++ b/btrbk
@@ -2464,10 +2464,11 @@ sub exit_status
 
 MAIN:
 {
-  # set PATH instead of using absolute "/sbin/btrfs" (for now), as
-  # different distros (and even different versions of btrfs-progs)
-  # install the "btrfs" executable to different locations.
-  $ENV{PATH} = '/sbin:/bin:/usr/sbin:/usr/bin';
+  # Prefix PATH with /sbin etc. instead of using absolute
+  # "/sbin/btrfs" (for now), as different distros (and even different
+  # versions of btrfs-progs) install the "btrfs" executable to
+  # different locations.
+  $ENV{PATH} .= '/sbin:/bin:/usr/sbin:/usr/bin';
 
   Getopt::Long::Configure qw(gnu_getopt);
   $Data::Dumper::Sortkeys = 1;


### PR DESCRIPTION
Some distros (notably NixOS) don't even use /usr/bin, /sbin, etc.
Instead, they use PATH to specify which programs are available to a
given executable.

This patch changes the behavior or `btrbk` so it extends PATH with its
own search paths instead of resetting it. This allows users and distros
to specify their own custom location for `btrfs` via `PATH`.