### PR TITLE
Update ssh_filter_btrbk.sh to use readlink

### DIFF
--- a/ssh_filter_btrbk.sh
+++ b/ssh_filter_btrbk.sh
@@ -102,7 +102,7 @@ while [[ "$#" -ge 1 ]]; do
       -t|--target)
           allow_cmd "btrfs receive"
           # the following are needed if targets point to a directory
-          allow_cmd "realpath"
+          allow_cmd "readlink"
           allow_exact_cmd "cat /proc/self/mounts"
           ;;
 


### PR DESCRIPTION
Replace realpath with readlink in allowed commands. Commit 796b6bd substituted readlink for realpath in file "btrbk"; this commit propagates the change to ssh_filter_btrbk.sh.