### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Retention policy:
 
   * keep all snapshots for 2 days, no matter how frequently you (or
     your cron-job) run btrbk
-  * keep latest daily snapshots for 14 days (very handy if you are on
+  * keep daily snapshots for 14 days (very handy if you are on
     the road and the backup disk is not attached)
   * keep monthly backups forever
   * keep weekly backups for 10 weeks


### PR DESCRIPTION
Under "Example: laptop with usb-disk for backups" the readme stated that " snapshot_preserve 14d" will "keep latest daily snapshots for 14 days [..]". I believe that this is misleading, as it seems to imply that only one snapshot --the latest -- will be kept in that period, when in fact _all_ snapshots will be kept in that period.