### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ snapshots and backups, as well as from the command line (e.g. for
 instantly creating additional snapshots).
 
 
-###Upgrading from v0.22.2
+### Upgrading from v0.22.2
 
 Please read the [upgrade guide](doc/upgrade_to_v0.23.0.md) if you are
 updating from btrbk <= v0.22.2.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
