### PR TITLE
Makefile: Preserve timestamps with install -p

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,38 +26,38 @@ all:
 
 install-bin:
 	@echo 'installing main script and config...'
-	install -Dm644 btrbk.conf.example "$(DESTDIR)$(CONFDIR)/btrbk/btrbk.conf.example"
-	install -Dm755 $(PN) "$(DESTDIR)$(BINDIR)/$(PN)"
+	install -pDm644 btrbk.conf.example "$(DESTDIR)$(CONFDIR)/btrbk/btrbk.conf.example"
+	install -pDm755 $(PN) "$(DESTDIR)$(BINDIR)/$(PN)"
 
 install-systemd:
 	@echo 'installing systemd service units...'
 	$(process) contrib/systemd/btrbk.service.in > contrib/systemd/btrbk.service.tmp
 	$(process) contrib/systemd/btrbk.timer.in > contrib/systemd/btrbk.timer.tmp
-	install -Dm644 contrib/systemd/btrbk.service.tmp "$(DESTDIR)$(SYSTEMDDIR)/btrbk.service"
-	install -Dm644 contrib/systemd/btrbk.timer.tmp "$(DESTDIR)$(SYSTEMDDIR)/btrbk.timer"
+	install -pDm644 contrib/systemd/btrbk.service.tmp "$(DESTDIR)$(SYSTEMDDIR)/btrbk.service"
+	install -pDm644 contrib/systemd/btrbk.timer.tmp "$(DESTDIR)$(SYSTEMDDIR)/btrbk.timer"
 	rm contrib/systemd/btrbk.service.tmp
 	rm contrib/systemd/btrbk.timer.tmp
 
 install-share:
 	@echo 'installing auxiliary scripts...'
-	install -Dm755 ssh_filter_btrbk.sh "$(DESTDIR)$(SCRIPTDIR)/ssh_filter_btrbk.sh"
-	install -Dm755 contrib/cron/btrbk-mail "$(DESTDIR)$(SCRIPTDIR)/btrbk-mail"
+	install -pDm755 ssh_filter_btrbk.sh "$(DESTDIR)$(SCRIPTDIR)/ssh_filter_btrbk.sh"
+	install -pDm755 contrib/cron/btrbk-mail "$(DESTDIR)$(SCRIPTDIR)/btrbk-mail"
 
 install-man:
 	@echo 'installing manpages...'
-	install -Dm644 doc/btrbk.1 "$(DESTDIR)$(MAN1DIR)/btrbk.1"
-	install -Dm644 doc/ssh_filter_btrbk.1 "$(DESTDIR)$(MAN1DIR)/ssh_filter_btrbk.1"
-	install -Dm644 doc/btrbk.conf.5 "$(DESTDIR)$(MAN5DIR)/btrbk.conf.5"
+	install -pDm644 doc/btrbk.1 "$(DESTDIR)$(MAN1DIR)/btrbk.1"
+	install -pDm644 doc/ssh_filter_btrbk.1 "$(DESTDIR)$(MAN1DIR)/ssh_filter_btrbk.1"
+	install -pDm644 doc/btrbk.conf.5 "$(DESTDIR)$(MAN5DIR)/btrbk.conf.5"
 	gzip -9f "$(DESTDIR)$(MAN1DIR)/btrbk.1"
 	gzip -9f "$(DESTDIR)$(MAN1DIR)/ssh_filter_btrbk.1"
 	gzip -9f "$(DESTDIR)$(MAN5DIR)/btrbk.conf.5"
 
 install-doc:
 	@echo 'installing documentation...'
-	install -Dm644 ChangeLog "$(DESTDIR)$(DOCDIR)/ChangeLog"
-	install -Dm644 README.md "$(DESTDIR)$(DOCDIR)/README.md"
-	install -Dm644 doc/FAQ.md "$(DESTDIR)$(DOCDIR)/FAQ.md"
-	install -Dm644 doc/upgrade_to_v0.23.0.md "$(DESTDIR)$(DOCDIR)/upgrade_to_v0.23.0.md"
+	install -pDm644 ChangeLog "$(DESTDIR)$(DOCDIR)/ChangeLog"
+	install -pDm644 README.md "$(DESTDIR)$(DOCDIR)/README.md"
+	install -pDm644 doc/FAQ.md "$(DESTDIR)$(DOCDIR)/FAQ.md"
+	install -pDm644 doc/upgrade_to_v0.23.0.md "$(DESTDIR)$(DOCDIR)/upgrade_to_v0.23.0.md"
 	gzip -9f "$(DESTDIR)$(DOCDIR)/ChangeLog"
 	gzip -9f "$(DESTDIR)$(DOCDIR)/README.md"
 	gzip -9f "$(DESTDIR)$(DOCDIR)/FAQ.md"


### PR DESCRIPTION
Hi! Please consider this patch to aid in reproducing builds. This patch simply adds `-p` to each `install` command in order to preserve the timestamps from the tarball.

I am submitting this to you as I am required to do this in order to pass review, and we generally try to work with upstream to merge any universal changes if possible. 

Thanks!