### PR TITLE
Make sure btrbk service only runs after network is available

### DIFF
--- a/contrib/systemd/btrbk.service.in
+++ b/contrib/systemd/btrbk.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=btrbk backup
+After=network.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Noticed that the `btrbk.service` was marked as failed last time I started my machine. This should prevent that.

As specified at https://www.freedesktop.org/software/systemd/man/systemd.timer.html#Persistent= the service will be activated immediately on machine boot. This makes it possible for the service to be activated before remote hosts are available. Adding the `After` directive should make sure that it is only triggered after remote hosts are reachable.