### PR TITLE
btrbk: it is now possible to back up a subvolume that is already mounted at /.

### DIFF
--- a/btrbk
+++ b/btrbk
@@ -5303,7 +5303,10 @@ MAIN:
         WARN "Skipping subvolume \"$svol->{PRINT}\": $abrt";
         next;
       }
-      if($svol->{node}{uuid} && _is_child_of($sroot->{node}, $svol->{node}{uuid})) {
+      if($svol->{node}{uuid} &&
+          (_is_child_of($sroot->{node}, $svol->{node}{uuid}) ||
+           ($svol->{node}{uuid} eq $sroot->{node}{uuid}))) 
+      {
         DEBUG "Found \"$svol->{PRINT}\" (id=$svol->{node}{id}) in btrfs subtree of: $sroot->{PRINT}";
       } else {
         ABORTED($svol, "Not a child subvolume of: $sroot->{PRINT}");


### PR DESCRIPTION
It works with the configuration snippet below:

```
volume /
  subvolume  .
    snapshot_create  ondemand
    snapshot_name    root
    target send-receive      /mnt/ext-backup/snapshots
```