### PR TITLE
Use `envsubst` instead of `sed` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,12 +40,8 @@ install-etc:
 install-systemd:
 	@echo 'installing systemd service units...'
 	install -d -m 755 "$(DESTDIR)$(SYSTEMDDIR)"
-	envsubst < contrib/systemd/btrbk.service.in > contrib/systemd/btrbk.service.tmp
-	envsubst < contrib/systemd/btrbk.timer.in > contrib/systemd/btrbk.timer.tmp
-	install -p -m 644 contrib/systemd/btrbk.service.tmp "$(DESTDIR)$(SYSTEMDDIR)/btrbk.service"
-	install -p -m 644 contrib/systemd/btrbk.timer.tmp "$(DESTDIR)$(SYSTEMDDIR)/btrbk.timer"
-	rm contrib/systemd/btrbk.service.tmp
-	rm contrib/systemd/btrbk.timer.tmp
+	envsubst < contrib/systemd/btrbk.service.in | install -p -m 644 /dev/stdin "$(DESTDIR)$(SYSTEMDDIR)/btrbk.service"
+	envsubst < contrib/systemd/btrbk.timer.in | install -p -m 644 /dev/stdin "$(DESTDIR)$(SYSTEMDDIR)/btrbk.timer"
 
 install-share:
 	@echo 'installing auxiliary scripts...'

--- a/Makefile
+++ b/Makefile
@@ -20,16 +20,8 @@ SYSTEMDDIR = $(PREFIX)/lib/systemd/system
 MAN1DIR    = $(PREFIX)/share/man/man1
 MAN5DIR    = $(PREFIX)/share/man/man5
 
-replace_vars = sed \
-	-e "s|@PN@|$(PN)|g" \
-	-e "s|@CONFDIR@|$(CONFDIR)|g" \
-	-e "s|@CRONDIR@|$(CRONDIR)|g" \
-	-e "s|@BINDIR@|$(BINDIR)|g" \
-	-e "s|@DOCDIR@|$(DOCDIR)|g" \
-	-e "s|@SCRIPTDIR@|$(SCRIPTDIR)|g" \
-	-e "s|@SYSTEMDDIR@|$(SYSTEMDDIR)|g" \
-	-e "s|@MAN1DIR@|$(MAN1DIR)|g" \
-	-e "s|@MAN5DIR@|$(MAN5DIR)|g"
+# make variables accessible to `envsubst`
+.EXPORT_ALL_VARIABLES:
 
 all: man
 
@@ -48,8 +40,8 @@ install-etc:
 install-systemd:
 	@echo 'installing systemd service units...'
 	install -d -m 755 "$(DESTDIR)$(SYSTEMDDIR)"
-	$(replace_vars) contrib/systemd/btrbk.service.in > contrib/systemd/btrbk.service.tmp
-	$(replace_vars) contrib/systemd/btrbk.timer.in > contrib/systemd/btrbk.timer.tmp
+	envsubst < contrib/systemd/btrbk.service.in > contrib/systemd/btrbk.service.tmp
+	envsubst < contrib/systemd/btrbk.timer.in > contrib/systemd/btrbk.timer.tmp
 	install -p -m 644 contrib/systemd/btrbk.service.tmp "$(DESTDIR)$(SYSTEMDDIR)/btrbk.service"
 	install -p -m 644 contrib/systemd/btrbk.timer.tmp "$(DESTDIR)$(SYSTEMDDIR)/btrbk.timer"
 	rm contrib/systemd/btrbk.service.tmp

--- a/contrib/systemd/btrbk.service.in
+++ b/contrib/systemd/btrbk.service.in
@@ -4,4 +4,4 @@ Documentation=man:btrbk(1)
 
 [Service]
 Type=oneshot
-ExecStart=@BINDIR@/btrbk run
+ExecStart=${BINDIR}/btrbk run


### PR DESCRIPTION
This leads to shorter syntax, and also uses a tool made for this purpose instead of a homemade `sed` solution.

On the negative side, `envsubst` is a part of `gettext`, so this change introduces a build dependency on `gettext`.