### PR TITLE
contrib: systemd: btrbk.timer: change install target

### DIFF
--- a/contrib/systemd/btrbk.timer.in
+++ b/contrib/systemd/btrbk.timer.in
@@ -7,4 +7,4 @@ AccuracySec=10min
 Persistent=true
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=timers.target


### PR DESCRIPTION
Noticed that `btrbk.timer` uses `WantedBy=multi-user.target`, while most timers use `WantedBy=timers.target`:

```
$ grep WantedBy= /usr/lib/systemd/system/*.timer
/usr/lib/systemd/system/btrbk.timer:WantedBy=multi-user.target
/usr/lib/systemd/system/btrfs-scrub@.timer:WantedBy=multi-user.target
/usr/lib/systemd/system/e2scrub_all.timer:WantedBy=timers.target
/usr/lib/systemd/system/fstrim.timer:WantedBy=timers.target
/usr/lib/systemd/system/logrotate.timer:WantedBy=timers.target
/usr/lib/systemd/system/man-db.timer:WantedBy=timers.target
/usr/lib/systemd/system/paccache.timer:WantedBy=timers.target
/usr/lib/systemd/system/xfs_scrub_all.timer:WantedBy=timers.target
```

Looked into it, and found out that I think btrbk could use `timers.target` too.

See commit message for more technical details.