### PR TITLE
ssh_filter_btrbk.sh: whitelist mkdir for 'btrbk archive' operations

### DIFF
--- a/ssh_filter_btrbk.sh
+++ b/ssh_filter_btrbk.sh
@@ -125,6 +125,7 @@ while [[ "$#" -ge 1 ]]; do
 
       -t|--target)
           allow_cmd "${sudo_prefix}btrfs receive"
+          allow_cmd "${sudo_prefix}mkdir"
           ;;
 
       -c|--compress)


### PR DESCRIPTION
An archive operation over ssh like `btrbk archive <volume> ssh://<host>/<volume>` requires the occasional use of mkdir. This is rejected by ssh_filter_btrbk.sh:

```
ERROR: ssh_filter_btrbk.sh: ssh command rejected: disallowed command: mkdir -p <volume>/<subdir>
WARNING: Skipping archive target "<host>:/<volume>/<subdir>": Failed to create directory: <host>:/<volume>/<subdir>/
```