### PR TITLE
Change shebang to use /usr/bin/env

### DIFF
--- a/btrbk
+++ b/btrbk
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # btrbk - Create snapshots and remote backups of btrfs subvolumes
 #


### PR DESCRIPTION
Makes the script more portable to systems where perl is not in /usr/bin, e.g. NixOS.