### PR TITLE
Add support for zstd adaptive compression. 

### DIFF
--- a/btrbk
+++ b/btrbk
@@ -54,8 +54,8 @@ my %compression = (
   xz     => { name => 'xz',     format => 'xz',  compress_cmd => [ 'xz',     '-c' ], decompress_cmd => [ 'xz',     '-d', '-c' ], level_min => 0, level_max => 9, threads => '-T' },
   lzo    => { name => 'lzo',    format => 'lzo', compress_cmd => [ 'lzop',   '-c' ], decompress_cmd => [ 'lzop',   '-d', '-c' ], level_min => 1, level_max => 9 },
   lz4    => { name => 'lz4',    format => 'lz4', compress_cmd => [ 'lz4',    '-c' ], decompress_cmd => [ 'lz4',    '-d', '-c' ], level_min => 1, level_max => 9 },
-  zstd   => { name => 'zstd',   format => 'zst', compress_cmd => [ 'zstd',   '-c' ], decompress_cmd => [ 'zstd',   '-d', '-c' ], level_min => 1, level_max => 19, threads => '-T', long => '--long=' },
- );
+  zstd   => { name => 'zstd',   format => 'zst', compress_cmd => [ 'zstd',   '-c' ], decompress_cmd => [ 'zstd',   '-d', '-c' ], level_min => 1, level_max => 19, threads => '-T', long => '--long=', adapt => '--adapt' },
+  );
 
 my $compress_format_alt = join '|', map { $_->{format} } values %compression; # note: this contains duplicate alternations
 my $ipv4_addr_match = qr/(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])/;
@@ -110,6 +110,7 @@ my %config_options = (
   stream_compress_level       => { default => "default", accept => [ "default" ], accept_numeric => 1 },
   stream_compress_long        => { default => "default", accept => [ "default" ], accept_numeric => 1 },
   stream_compress_threads     => { default => "default", accept => [ "default" ], accept_numeric => 1 },
+  stream_compress_adapt       => { default => undef,     accept => [ "no","default" ] },
 
   raw_target_compress         => { default => undef,     accept => [ "no", (keys %compression) ] },
   raw_target_compress_level   => { default => "default", accept => [ "default" ], accept_numeric => 1 },
@@ -690,6 +691,18 @@ sub compress_cmd_text($;$)
     }
     else {
       WARN_ONCE "Long distance matching is not supported for '$cc->{name}', ignoring";
+    }
+  }
+  if(defined($def->{adapt}) && ($def->{adapt} eq "default")) {
+    my $adapt_opt = $cc->{adapt};
+    if($adapt_opt) {
+      if(($cc->{name} eq "zstd" ) && ( $def->{threads} ne 1 ) ) {
+        WARN_ONCE "Adaptive compression for '$cc->{name}' drifts to higher compression levels with multiple threads. Recommend setting threads to 1";
+      }
+        push @cmd, $adapt_opt;
+    }
+    else {
+      WARN_ONCE "Adaptive compression is not supported for '$cc->{name}', ignoring"; 
     }
   }
   return { cmd_text => join(' ', @cmd) };
@@ -3956,6 +3969,8 @@ sub config_compress_hash($$)
     level   => config_key($config, $config_key . "_level"),
     long    => config_key($config, $config_key . "_long"),
     threads => config_key($config, $config_key . "_threads"),
+    adapt   => config_key($config, $config_key . "_adapt"),
+    
   };
 }
 


### PR DESCRIPTION
Requires zstd version >= 1.3.6.
Adds stream_compress_adapt parameter in the config file to enable adaptive compression levels.
Allowed values for stream_compress_adapt are:
  no          : disables adaptive compression in zstd
  default   : enables adaptive compression with default min and max compression levels
