### PR TITLE
 On branch sync-after-delete

### DIFF
--- a/btrbk
+++ b/btrbk
@@ -321,6 +321,7 @@ my %backend_cmd_map = (
                            "btrfs subvolume snapshot" => [ "sudo", "-n", "btrfs", "subvolume", "snapshot" ],
                            "btrfs subvolume delete"   => [ "sudo", "-n", "btrfs", "subvolume", "delete"   ],
                            "btrfs subvolume sync"     => [ "sudo", "-n", "btrfs", "subvolume", "sync"     ],
+                           "btrfs filesystem sync"    => [ "sudo", "-n", "btrfs", "filesystem", "sync"    ],
                            "btrfs send"               => [ "sudo", "-n", "btrfs", "send"                  ],
                            "btrfs receive"            => [ "sudo", "-n", "btrfs", "receive"               ],
                            "btrfs filesystem usage"   => [ "sudo", "-n", "btrfs", "filesystem", "usage"   ],
@@ -1476,6 +1477,9 @@ sub btrfs_subvolume_delete($@)
                        rsh => vinfo_rsh($target),
                        fatal_stderr  => sub { m/^ERROR: /; },  # probably not needed, "btrfs sub delete" returns correct exit status
                        filter_stderr => \&_btrfs_filter_stderr,
+                      );
+        $ret = run_cmd(cmd => vinfo_cmd($target, "btrfs filesystem sync", { unsafe => $target->{VINFO_MOUNTPOINT}{PATH} } ),
+                       rsh => vinfo_rsh($target),
                       );
         $ret = run_cmd(cmd => vinfo_cmd($target, "btrfs subvolume sync", { unsafe => $target->{VINFO_MOUNTPOINT}{PATH} }, $target->{node}{id} ),
                        rsh => vinfo_rsh($target),

--- a/ssh_filter_btrbk.sh
+++ b/ssh_filter_btrbk.sh
@@ -140,6 +140,8 @@ while [[ "$#" -ge 1 ]]; do
 
       -d|--delete)
           allow_cmd "${sudo_prefix}btrfs subvolume delete"
+          allow_cmd "${sudo_prefix}btrfs subvolume sync"
+          allow_cmd "${sudo_prefix}btrfs filesystem sync"
           ;;
 
       -i|--info)


### PR DESCRIPTION
 Your branch is up to date with 'origin/sync-after-delete'.

 Changes to be committed:
	modified:   btrbk
	modified:   ssh_filter_btrbk.sh

btrbk:
- included the btrbk filesystem sync command for btrfs-progs-sudo
- inserted the btrbk filesystem sync command in between btrfs subvolume delete and btrfs subvolume sync in case "btrfs_commit_delete=sync"

Rationale:
The btrfs filesystem sync actually triggers the deletion of the subvolume right away. Therefore, btrfs subvolume sync does not wait so long.