### PR TITLE
Fix openssh website URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For more information, read the [installation documentation].
 
   [btrfs-progs]: https://www.kernel.org/pub/linux/kernel/people/kdave/btrfs-progs/
   [Perl interpreter]: https://www.perl.org
-  [OpenSSH]: https://www.openssh.org
+  [OpenSSH]: https://www.openssh.com
   [mbuffer]: https://www.maier-komor.de/mbuffer.html
 
 


### PR DESCRIPTION
It looks like the canonical domain for openssh is www.openssh.com. The alternative domain used currently in btrbk docs (openssh.org) redirects to openssh.com. However, that domain happens to be not included in the list of subject alt names of openbsd LE certificate:

```
$ curl https://www.openssh.org/
curl: (60) SSL: no alternative certificate subject name matches target host name 'www.openssh.org'
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```