### PR TITLE
Fix issues with 0 sized info files for raw backup

### DIFF
--- a/btrbk
+++ b/btrbk
@@ -2005,6 +2005,7 @@ sub system_read_raw_info_dir($)
     cmd => [ 'find', { unsafe => $droot->{PATH} },
              '-maxdepth', '1',
              '-type', 'f',
+             '! -size', 0,
              '-name', '\*.btrfs.\*info',  # match ".btrfs[.gz|bz2|xz][.gpg].info"
              '-exec', 'echo INFO_FILE=\{\} \;',
              '-exec', 'cat \{\} \;'


### PR DESCRIPTION
When backuping from devices that have configured to use raw backup and that might disconnect from the network (ie. laptops) you end up once in a while with 0 size info file (and backup file).
btrbk don't know how to handle 0 file and stop backing up until the zero size file is removed.
With this change 0 size info file will be ignored, and hence the backup for the given backup will be redone.

Signed-off-by: Matthieu Patou <mat@matws.net>