### PR TITLE
btrbk: add bzip3 compression

### DIFF
--- a/btrbk
+++ b/btrbk
@@ -727,7 +727,9 @@ sub compress_cmd_text($;$)
       WARN_ONCE "Compression level capped to maximum for '$cc->{name}': $cc->{level_max}";
       $level = $cc->{level_max};
     }
-    push @cmd, '-' . $level;
+    if($cc->{level_min} >= 0) {
+      push @cmd, '-' . $level;
+    }
   }
   if(defined($def->{threads}) && ($def->{threads} ne "default")) {
     my $thread_opt = $cc->{threads};

--- a/btrbk
+++ b/btrbk
@@ -51,6 +51,7 @@ my %compression = (
   gzip   => { name => 'gzip',   format => 'gz',  compress_cmd => [ 'gzip',   '-c' ], decompress_cmd => [ 'gzip',   '-d', '-c' ], level_min => 1, level_max => 9 },
   pigz   => { name => 'pigz',   format => 'gz',  compress_cmd => [ 'pigz',   '-c' ], decompress_cmd => [ 'pigz',   '-d', '-c' ], level_min => 1, level_max => 9, threads => '-p' },
   bzip2  => { name => 'bzip2',  format => 'bz2', compress_cmd => [ 'bzip2',  '-c' ], decompress_cmd => [ 'bzip2',  '-d', '-c' ], level_min => 1, level_max => 9 },
+  bzip3  => { name => 'bzip3',  format => 'bz3', compress_cmd => [ 'bzip3',  '-c' ], decompress_cmd => [ 'bzip3',  '-d', '-c' ], level_min => -1, level_max => -1, threads => '-j' },
   pbzip2 => { name => 'pbzip2', format => 'bz2', compress_cmd => [ 'pbzip2', '-c' ], decompress_cmd => [ 'pbzip2', '-d', '-c' ], level_min => 1, level_max => 9, threads => '-p' },
   xz     => { name => 'xz',     format => 'xz',  compress_cmd => [ 'xz',     '-c' ], decompress_cmd => [ 'xz',     '-d', '-c' ], level_min => 0, level_max => 9, threads => '-T' },
   lzo    => { name => 'lzo',    format => 'lzo', compress_cmd => [ 'lzop',   '-c' ], decompress_cmd => [ 'lzop',   '-d', '-c' ], level_min => 1, level_max => 9 },
@@ -64,7 +65,7 @@ my $ipv6_addr_match = qr/[a-fA-F0-9]*:[a-fA-F0-9]*:[a-fA-F0-9:]+/; # simplified 
 my $host_name_match = qr/(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])/;
 my $uuid_match = qr/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
 my $btrbk_timestamp_match = qr/(?<YYYY>[0-9]{4})(?<MM>[0-9]{2})(?<DD>[0-9]{2})(T(?<hh>[0-9]{2})(?<mm>[0-9]{2})((?<ss>[0-9]{2})(?<zz>(Z|[+-][0-9]{4})))?)?(_(?<NN>[0-9]+))?/;  # matches "YYYYMMDD[Thhmm[ss+0000]][_NN]"
-my $raw_postfix_match = qr/\.btrfs(\.($compress_format_alt))?(\.(gpg|encrypted))?/;  # matches ".btrfs[.gz|bz2|xz][.gpg|encrypted]"
+my $raw_postfix_match = qr/\.btrfs(\.($compress_format_alt))?(\.(gpg|encrypted))?/;  # matches ".btrfs[.gz|bz2|bz3|xz][.gpg|encrypted]"
 my $safe_file_match = qr/[0-9a-zA-Z_@\+\-\.\/]+/;  # note: ubuntu uses '@' in the subvolume layout: <https://help.ubuntu.com/community/btrfs>
 
 my $group_match = qr/[a-zA-Z0-9_:-]+/;
@@ -2009,7 +2010,7 @@ sub system_read_raw_info_dir($)
              '-maxdepth', '1',
              '-type', 'f',
              '!', '-size', '0',
-             '-name', '\*.btrfs.\*info',  # match ".btrfs[.gz|bz2|xz][.gpg].info"
+             '-name', '\*.btrfs.\*info',  # match ".btrfs[.gz|bz2|bz3|xz][.gpg].info"
              '-exec', 'echo INFO_FILE=\{\} \;',
              '-exec', 'cat \{\} \;'
             ],

--- a/contrib/migration/raw_suffix2sidecar
+++ b/contrib/migration/raw_suffix2sidecar
@@ -38,11 +38,11 @@ our $PROJECT_HOME = '<https://digint.ch/btrbk/>';
 
 my  $VERSION_INFO = "raw_suffix2sidecar (btrbk migration script), version $VERSION";
 
-my $compress_format_alt = 'gz|bz2|xz|lzo|lz4';
+my $compress_format_alt = 'gz|bz2|bz3|xz|lzo|lz4';
 my $file_match = qr/[0-9a-zA-Z_@\+\-\.\/]+/;  # note: ubuntu uses '@' in the subvolume layout: <https://help.ubuntu.com/community/btrfs>
 my $uuid_match = qr/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
 my $timestamp_postfix_match = qr/\.(?<YYYY>[0-9]{4})(?<MM>[0-9]{2})(?<DD>[0-9]{2})(T(?<hh>[0-9]{2})(?<mm>[0-9]{2})((?<ss>[0-9]{2})(?<zz>(Z|[+-][0-9]{4})))?)?(_(?<NN>[0-9]+))?/;  # matches "YYYYMMDD[Thhmm[ss+0000]][_NN]"
-my $raw_postfix_match = qr/--(?<received_uuid>$uuid_match)(\@(?<parent_uuid>$uuid_match))?\.btrfs?(\.(?<compress>($compress_format_alt)))?(\.(?<encrypt>gpg))?(\.(?<split>split_aa))?(\.(?<incomplete>part))?/;  # matches ".btrfs_<received_uuid>[@<parent_uuid>][.gz|bz2|xz][.gpg][.split_aa][.part]"
+my $raw_postfix_match = qr/--(?<received_uuid>$uuid_match)(\@(?<parent_uuid>$uuid_match))?\.btrfs?(\.(?<compress>($compress_format_alt)))?(\.(?<encrypt>gpg))?(\.(?<split>split_aa))?(\.(?<incomplete>part))?/;  # matches ".btrfs_<received_uuid>[@<parent_uuid>][.gz|bz2|bz3|xz][.gpg][.split_aa][.part]"
 
 my $dryrun;
 

--- a/doc/btrbk.conf.5.asciidoc
+++ b/doc/btrbk.conf.5.asciidoc
@@ -273,8 +273,8 @@ set to ``all'' (the default).
     Compress the btrfs send stream before transferring it from/to
     remote locations. Defaults to ``no''. If enabled, make sure that
     '<compress_command>' is available on the source and target
-    hosts. Supported '<compress_command>': gzip, pigz, bzip2, pbzip2,
-    xz, lzo, lz4, zstd.
+    hosts. Supported '<compress_command>': gzip, pigz, bzip2, bzip3,
+    pbzip2, xz, lzo, lz4, zstd.
 
 *stream_compress_level* default|<number>::
     Compression level for the specified '<compress_command>'. Refer to
@@ -289,7 +289,7 @@ set to ``all'' (the default).
 
 *stream_compress_threads* default|<number>::
     Number of threads to use for <compress_command>. Only supported
-    for "pigz", "pbzip2", "zstd" and recent versions of "xz".
+    for "pigz", "bzip3", "pbzip2", "zstd" and recent versions of "xz".
 
 *stream_compress_adapt* default|<number>::
     Enable adaptive compression for <compress_command>. Only supported
@@ -612,8 +612,8 @@ files)!
 Raw backups consist of two files: the main data file containing the
 btrfs send stream, and a sidecar file ".info" containing metadata:
 
-  <snapshot-name>.<timestamp>[_N].btrfs[.gz|.bz2|.xz][.gpg]
-  <snapshot-name>.<timestamp>[_N].btrfs[.gz|.bz2|.xz][.gpg].info
+  <snapshot-name>.<timestamp>[_N].btrfs[.gz|.bz2|.bz3|.xz][.gpg]
+  <snapshot-name>.<timestamp>[_N].btrfs[.gz|.bz2|.bz3|.xz][.gpg].info
 
 For 'incremental' backups ("incremental yes"), please note that:
 
@@ -633,8 +633,8 @@ Additional options for raw targets:
 
 *raw_target_compress* <compress_command>|no::
     Compression algorithm to use for raw backup target. Supported
-    '<compress_command>': gzip, pigz, bzip2, pbzip2, xz, lzo, lz4,
-    zstd.
+    '<compress_command>': gzip, pigz, bzip2, bzip3, pbzip2, xz, lzo,
+    lz4, zstd.
 *raw_target_compress_level* default|<number>::
     Compression level for the specified <compress_command>.
 *raw_target_compress_long* default|<number>::

--- a/doc/ssh_filter_btrbk.1.asciidoc
+++ b/doc/ssh_filter_btrbk.1.asciidoc
@@ -39,8 +39,8 @@ The following commands are always allowed:
  - "readlink"
  - "test -d" (only if "compat busybox" configuration option is set)
  - "cat /proc/self/mountinfo"
- - pipes through "gzip", "pigz", "bzip2", "pbzip2", "xz", "lzop",
-   "lz4", "zstd" (stream_compress)
+ - pipes through "gzip", "pigz", "bzip2", "bzip3", "pbzip2", "xz",
+   "lzop", "lz4", "zstd" (stream_compress)
  - pipes through "mbuffer" (stream_buffer, rate_limit)
 
 Example line in /root/.ssh/authorized_keys on a backup target host:

--- a/ssh_filter_btrbk.sh
+++ b/ssh_filter_btrbk.sh
@@ -12,7 +12,7 @@ allow_exact_list=
 allow_rate_limit=1
 allow_stream_buffer=1
 allow_compress=1
-compress_list="gzip|pigz|bzip2|pbzip2|xz|lzop|lz4|zstd"
+compress_list="gzip|pigz|bzip2|bzip3|pbzip2|xz|lzop|lz4|zstd"
 
 # note that the backslash is NOT a metacharacter in a POSIX bracket expression!
 option_match='-[a-zA-Z0-9=-]+'   # matches short as well as long options


### PR DESCRIPTION
`bzip3` is now in Debian sid and shows quite remarkable performance.

Compressing the contents of the decompressed `linux-source-6.0` 6.0.8-1’s `/usr/src/linux-source-6.0.tar.xz` with 1 thread and `xz` gives:
```
$ tar -cf - linux-source-6.0 | /usr/bin/time --verbose xz -T 1 > xz.1.xz
	Command being timed: "xz -T 1"
	User time (seconds): 314.96
	System time (seconds): 0.50
	Percent of CPU this job got: 99%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 5:15.48
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 97588
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 0
	Minor (reclaiming a frame) page faults: 5603
	Voluntary context switches: 1
	Involuntary context switches: 2338
	Swaps: 0
	File system inputs: 0
	File system outputs: 0
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```

The same (also 1 thread) with `bzip2`:
```
$ tar -cf - linux-source-6.0 | /usr/bin/time --verbose bzip3 -j 1 > bz3.1.bz3
	Command being timed: "bzip3 -j 1"
	User time (seconds): 65.07
	System time (seconds): 0.49
	Percent of CPU this job got: 99%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 1:05.84
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 91284
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 1
	Minor (reclaiming a frame) page faults: 1082
	Voluntary context switches: 43183
	Involuntary context switches: 489
	Swaps: 0
	File system inputs: 184
	File system outputs: 0
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```
and it's even smaller:
```
$ ls -al bz3.1.bz3 xz.1.xz 
-rw-r--r-- 1 calestyo calestyo 131967354 Nov 15 03:04 bz3.1.bz3
-rw-r--r-- 1 calestyo calestyo 133976848 Nov 15 03:02 xz.1.xz
```

Right now this PR wouldn't work, though, because `bzip3` doesn't support (or at least ignore) `-#` options for the level.

I've filed https://github.com/kspalaiologos/bzip3/issues/78 asking for this. If it was implemented, I guess we shouldn't mention that it's ignored, because it may have an actual effect in some future..