### PR TITLE
btrbk: default to start weeks on mondays

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+btrbk-current
+  * Changed the default of "preserve_day_of_week" to "monday" in
+    accordance with the start of an ISO 8601 week as well as the
+    meaning of "weekly" in systemd.
+
 btrbk-0.32.5
 
   * Correct handling of zero-size raw info file (close #491).

--- a/btrbk
+++ b/btrbk
@@ -90,7 +90,7 @@ my %config_options = (
   incremental_prefs           => { default => \@incremental_prefs_default, accept => [ qr/$incremental_prefs_match/ ], split => 1 },
   incremental_clones          => { default => "yes",         accept => [qw( yes no )] },
   incremental_resolve         => { default => "mountpoint",  accept => [qw( mountpoint directory _all_accessible )] },
-  preserve_day_of_week        => { default => "sunday",      accept => [ (keys %day_of_week_map) ] },
+  preserve_day_of_week        => { default => "monday",      accept => [ (keys %day_of_week_map) ] },
   preserve_hour_of_day        => { default => 0,             accept => [ (0..23) ]  },
   snapshot_preserve           => { default => undef,         accept => [qw( no )], accept_preserve_matrix => 1, context => [qw( global volume subvolume )], },
   snapshot_preserve_min       => { default => "all",         accept => [qw( all latest ), qr/[1-9][0-9]*[hdwmy]/ ], context => [qw( global volume subvolume )], },

--- a/btrbk.conf.example
+++ b/btrbk.conf.example
@@ -56,7 +56,7 @@ snapshot_dir               _btrbk_snap
 
 # Specify on which day of week weekly/monthly backups are to be
 # preserved.
-#preserve_day_of_week       sunday
+#preserve_day_of_week       monday
 
 # Preserve all snapshots for a minimum period of time.
 #snapshot_preserve_min      1d

--- a/doc/btrbk.conf.5.asciidoc
+++ b/doc/btrbk.conf.5.asciidoc
@@ -179,7 +179,7 @@ not be certain about this, such operations are disallowed in
     Defines on what day a snapshot/backup is considered to be a
     "weekly" backup. Weekly, monthly and yearly backups are preserved
     on this day of week (see <<_retention_policy,RETENTION POLICY>>
-    below). Defaults to ``sunday''.
+    below). Defaults to ``monday''.
 
 *preserve_hour_of_day* [0..23]::
     Defines after what time (in full hours since midnight) a


### PR DESCRIPTION
Changed the default of the `preserve_day_of_week`-option to `monday` in accordance with the start of an ISO 8601 week as well as the meaning of `weekly` systemd.

Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>