### PR TITLE
ssh_filter_btrbk.sh: disallow newlines in the SSH command

### DIFF
--- a/ssh_filter_btrbk.sh
+++ b/ssh_filter_btrbk.sh
@@ -183,6 +183,8 @@ restrict_path_list=${restrict_path_list#\|}
 
 case "$SSH_ORIGINAL_COMMAND" in
     *\.\./*)  reject_and_die 'directory traversal'  ;;
+    *'
+'*)           reject_and_die 'unsafe character LF'  ;;
     *\$*)     reject_and_die 'unsafe character "$"' ;;
     *\&*)     reject_and_die 'unsafe character "&"' ;;
     *\(*)     reject_and_die 'unsafe character "("' ;;


### PR DESCRIPTION
This disallows newline (that is: LF characters) in the SSH command, which could have been exploited for arbitrary code execution, since commit 77a39282de6fdc98cad1270c6b5b6105629d5e5a.

Example:

Since `readlink` is a generally allowed command, this works with any of ssh_filter_btrbk.sh’s options.
But most likely, other commands that are “added” via `allow_cmd()` can be used, too.

Signed-off-by: Christoph Anton Mitterer <mail@christoph.anton.mitterer.name>