### PR TITLE
Implement "synology" compat option for Synology NAS

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+ unreleased
+
+  * Add "synology" compat option for Synology NAS.
+
 btrbk-0.32.6
 
   * Fix backup of unrelated (by parent_uuid) snapshots (close #339).

--- a/btrbk
+++ b/btrbk
@@ -142,9 +142,9 @@ my %config_options = (
   backend_remote              => { default => undef,         accept => [qw( no btrfs-progs btrfs-progs-btrbk btrfs-progs-sudo btrfs-progs-doas )] },
   backend_local_user          => { default => undef,         accept => [qw( no btrfs-progs btrfs-progs-btrbk btrfs-progs-sudo btrfs-progs-doas )] },
 
-  compat                      => { default => undef,         accept => [qw( no busybox ignore_receive_errors )], split => 1 },
-  compat_local                => { default => undef,         accept => [qw( no busybox ignore_receive_errors )], split => 1 },
-  compat_remote               => { default => undef,         accept => [qw( no busybox ignore_receive_errors )], split => 1 },
+  compat                      => { default => undef,         accept => [qw( no busybox ignore_receive_errors synology )], split => 1 },
+  compat_local                => { default => undef,         accept => [qw( no busybox ignore_receive_errors synology )], split => 1 },
+  compat_remote               => { default => undef,         accept => [qw( no busybox ignore_receive_errors synology )], split => 1 },
   safe_commands               => { default => undef,         accept => [qw( yes no )], context => [qw( global )] },
   btrfs_commit_delete         => { default => undef,         accept => [qw( yes no after each )],
                                                              deprecated => { MATCH => { regex => qr/^(?:after|each)$/, warn => 'Please use "btrfs_commit_delete yes|no"', replace_key => "btrfs_commit_delete", replace_value => "yes" } } },
@@ -1461,11 +1461,13 @@ sub _btrfs_send_options($$;$$)
   my $clone_src = shift // [];
   my $send_protocol = config_key($target, "send_protocol");
   my $send_compressed_data = config_key($target, "send_compressed_data");
+  my $compat_synology = config_key_lru($target, "compat", "synology");
   my @send_options;
   push(@send_options, '-p', { unsafe => $parent->{PATH} } ) if($parent);
   push(@send_options, '-c', { unsafe => $_ } ) foreach(map { $_->{PATH} } @$clone_src);
   push(@send_options, '--proto', $send_protocol ) if($send_protocol);
   push(@send_options, '--compressed-data' ) if($send_compressed_data);
+  push(@send_options, '--without-syno-features' ) if($compat_synology);
   #push(@send_options, '-v') if($loglevel >= 3);
   return \@send_options;
 }

--- a/btrbk.conf.example
+++ b/btrbk.conf.example
@@ -202,3 +202,18 @@ volume ssh://my-remote-host.com/mnt/btr_pool
   snapshot_preserve_min  all
   subvolume home
     target /mnt/btr_backup/my-remote-host.com
+
+# Archive all shared folders from a Synology NAS btrfs.
+# Needs an admin account with SSH key login.
+volume ssh://my-synology-host.com/volume1
+  subvolume *
+  compat synology
+
+  snapshot_dir           btrbk_snapshots
+  snapshot_create        ondemand
+  snapshot_preserve_min  latest
+  snapshot_preserve      no
+
+  target_preserve_min    6m
+  target_preserve        10d 10w 12m
+  target /mnt/btr_backup/my-synology-host.com

--- a/doc/btrbk.conf.5.asciidoc
+++ b/doc/btrbk.conf.5.asciidoc
@@ -417,6 +417,12 @@ with "ERROR: attribute 12 requested but not present".
 Note that there is *no guarantee that backups created with this
 option enabled can be restored at all*.
 
+*synology*::
+    Useful when transfering snapshots from Synology DSM NAS systems, that
+    are normally not compatible with standard Btrfs systems and sending
+    would cause a lot of ACL errors. When this is enabled, the option
+    `--without-syno-features` is passed to `btrfs send`.
+
 If you want to set this option for local or remote hosts only, set
 *compat_local* or *compat_remote* (e.g. "compat_remote busybox").
 --


### PR DESCRIPTION
By default, the Synology "btrfs send" command will send a lot of ACLs and maybe other information, a standard btrfs can't deal with.
I've discovered that it's possible to turn this behavior off with `--without-syno-features` and let it behave like a normal `btrfs send`, allowing btrbk to send Snapshots to a non Synology btrfs.

Maybe #383 already tried to address this issue, but for me the btrbk run still failed. With this change here, all receive errors are gone.

I've also added an example in the config how to archive all Synology subfolders at once.
