### PR TITLE
Add new systemd service which waits for network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,12 @@ install-systemd:
 	install -p -m 644 contrib/systemd/btrbk.timer.tmp "$(DESTDIR)$(SYSTEMDDIR)/btrbk.timer"
 	rm contrib/systemd/btrbk.service.tmp
 	rm contrib/systemd/btrbk.timer.tmp
+	$(replace_vars) contrib/systemd/btrbk-network.service.in > contrib/systemd/btrbk-network.service.tmp
+	$(replace_vars) contrib/systemd/btrbk-network.timer.in > contrib/systemd/btrbk-network.timer.tmp
+	install -p -m 644 contrib/systemd/btrbk-network.service.tmp "$(DESTDIR)$(SYSTEMDDIR)/btrbk-network.service"
+	install -p -m 644 contrib/systemd/btrbk-network.timer.tmp "$(DESTDIR)$(SYSTEMDDIR)/btrbk-network.timer"
+	rm contrib/systemd/btrbk-network.service.tmp
+	rm contrib/systemd/btrbk.timer-network.tmp
 
 install-share:
 	@echo 'installing auxiliary scripts...'

--- a/README.md
+++ b/README.md
@@ -667,6 +667,25 @@ Btrfs Relationship (technical note)
     * Used by btrbk to determine best parent.
     * `/mnt/btr_pool/data.20150101 <-- /mnt/btr_pool/data`
 
+SystemD
+=======
+
+There are 2 systemD units available. One for local backups and one with networking support. They run a daily snapshot and can be enabled with their timers.
+
+Only one of these should be enabled at the same time.
+
+For local only:
+
+```
+sudo systemctl enable --now btrbk.timer
+```
+
+For networking support, like SSH targets and sources:
+
+```
+sudo systemctl enable --now btrbk-network.timer
+```
+
 
 FAQ
 ===

--- a/contrib/systemd/btrbk-network.service.in
+++ b/contrib/systemd/btrbk-network.service.in
@@ -1,0 +1,8 @@
+[Unit]
+Description=btrbk backup
+Documentation=man:btrbk(1)
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=@BINDIR@/btrbk run

--- a/contrib/systemd/btrbk-network.timer.in
+++ b/contrib/systemd/btrbk-network.timer.in
@@ -1,0 +1,10 @@
+[Unit]
+Description=btrbk daily backup (with network support)
+
+[Timer]
+OnCalendar=daily
+AccuracySec=10min
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
The current systemd service starts too early in the boot process, so remote targets can not be reached (see #486 ).

To get around this, we create a new service that waits until the network stack is started on the system.

Then people can decide if they just need the default one for local storage or if they need the network based one for SSH targets and such.

Should fix #486