### PR TITLE
[systemd] Add delay.timer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ BINDIR      = $(PREFIX)/bin
 DOCDIR      = $(PREFIX)/share/doc/$(PN)
 SCRIPTDIR   = $(PREFIX)/share/$(PN)/scripts
 SYSTEMDDIR  = $(PREFIX)/lib/systemd/system
-TIMERCONF   = $(CONFDIR)/systemd/system/btrbk.timer.d
+TIMERCONF   = $(CONFDIR)/systemd/system
 BASHCOMPDIR = $(PREFIX)/share/bash-completion/completions
 MAN1DIR     = $(PREFIX)/share/man/man1
 MAN5DIR     = $(PREFIX)/share/man/man5
@@ -45,6 +45,7 @@ replace_vars = sed \
 	-e "s|@DOCDIR@|$(DOCDIR)|g" \
 	-e "s|@SCRIPTDIR@|$(SCRIPTDIR)|g" \
 	-e "s|@SYSTEMDDIR@|$(SYSTEMDDIR)|g" \
+	-e "s|@TIMERCONF@|$(TIMERCONF)|g" \
 	-e "s|@BASHCOMPDIR@|$(BASHCOMPDIR)|g" \
 	-e "s|@MAN1DIR@|$(MAN1DIR)|g" \
 	-e "s|@MAN5DIR@|$(MAN5DIR)|g"
@@ -80,16 +81,16 @@ install-completion:
 install-systemd:
 	@echo 'installing systemd service units...'
 	install -d -m 755 "$(DESTDIR)$(SYSTEMDDIR)"
-        install -d -m 755 "$(TIMERCONF)"
+	install -d -m 755 "$(DESTDIR)$(TIMERCONF)/btrbk.timer.d"
 	$(replace_vars) contrib/systemd/btrbk.service.in > contrib/systemd/btrbk.service.tmp
 	$(replace_vars) contrib/systemd/btrbk.timer.in > contrib/systemd/btrbk.timer.tmp
-        $(replace_vars) contrib/systemd/delay.timer.in > contrib/systemd/delay.timer.tmp
+	$(replace_vars) contrib/systemd/delay.timer.in > contrib/systemd/delay.timer.tmp
 	install -p -m 644 contrib/systemd/btrbk.service.tmp "$(DESTDIR)$(SYSTEMDDIR)/btrbk.service"
 	install -p -m 644 contrib/systemd/btrbk.timer.tmp "$(DESTDIR)$(SYSTEMDDIR)/btrbk.timer"
-        install -p -m 644 contrib/systemd/delay.timer.tmp "$(TIMERCONF)"/delay.timer"
+	install -p -m 644 contrib/systemd/delay.timer.tmp "$(DESTDIR)$(TIMERCONF)/btrbk.timer.d/delay.timer"
 	rm contrib/systemd/btrbk.service.tmp
 	rm contrib/systemd/btrbk.timer.tmp
-        rm contrib/systemd/delay.timer.tmp
+	rm contrib/systemd/delay.timer.tmp
 
 install-share:
 	@echo 'installing auxiliary scripts...'

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ BINDIR      = $(PREFIX)/bin
 DOCDIR      = $(PREFIX)/share/doc/$(PN)
 SCRIPTDIR   = $(PREFIX)/share/$(PN)/scripts
 SYSTEMDDIR  = $(PREFIX)/lib/systemd/system
+TIMERCONF   = $(CONFDIR)/systemd/system/btrbk.timer.d
 BASHCOMPDIR = $(PREFIX)/share/bash-completion/completions
 MAN1DIR     = $(PREFIX)/share/man/man1
 MAN5DIR     = $(PREFIX)/share/man/man5
@@ -79,12 +80,16 @@ install-completion:
 install-systemd:
 	@echo 'installing systemd service units...'
 	install -d -m 755 "$(DESTDIR)$(SYSTEMDDIR)"
+        install -d -m 755 "$(TIMERCONF)"
 	$(replace_vars) contrib/systemd/btrbk.service.in > contrib/systemd/btrbk.service.tmp
 	$(replace_vars) contrib/systemd/btrbk.timer.in > contrib/systemd/btrbk.timer.tmp
+        $(replace_vars) contrib/systemd/delay.timer.in > contrib/systemd/delay.timer.tmp
 	install -p -m 644 contrib/systemd/btrbk.service.tmp "$(DESTDIR)$(SYSTEMDDIR)/btrbk.service"
 	install -p -m 644 contrib/systemd/btrbk.timer.tmp "$(DESTDIR)$(SYSTEMDDIR)/btrbk.timer"
+        install -p -m 644 contrib/systemd/delay.timer.tmp "$(TIMERCONF)"/delay.timer"
 	rm contrib/systemd/btrbk.service.tmp
 	rm contrib/systemd/btrbk.timer.tmp
+        rm contrib/systemd/delay.timer.tmp
 
 install-share:
 	@echo 'installing auxiliary scripts...'

--- a/contrib/systemd/delay.timer.in
+++ b/contrib/systemd/delay.timer.in
@@ -1,0 +1,3 @@
+[Timer]
+OnBootSec=5m
+Persistent=no


### PR DESCRIPTION
The current systemd timer triggers to soon in the boot process for network based source and destinations to be available.
See #486 
Creating a drop-in timer in /etc/systemd/system/btrbk.timer.d/ with a delay works.

This PR adds a delay.timer unit with a 5 min delay that makes the timer wait for 5 minutes before it runs the backup. This should be more than enough time to make sure any remote source or destination is available to the system. If needed, we can adjust the delay by just changing the `OnBootSec=5m` line in delay.time.in to something more appropriate.

Should fix #486 .